### PR TITLE
Force c++11 for g++ 5.4.0 on Nvidia Jetson TX2

### DIFF
--- a/desktop/openecar_dashboard.pro
+++ b/desktop/openecar_dashboard.pro
@@ -5,6 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui serialbus
+CONFIG += c++11
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 


### PR DESCRIPTION
Otherwise we get error messages like:
error: ‘nullptr’ was not declared in this scope
...

Signed-off-by: Abylay Ospan <aospanjokersys.com>