### PR TITLE
Time display format change

### DIFF
--- a/desktop/opencardashboard.cpp
+++ b/desktop/opencardashboard.cpp
@@ -70,7 +70,7 @@ void OpencarDashboard::refreshScreen()
 {
     if(!CANisOK)return;
     if(!can)return;
-    ui->label_Vdatetime->setText(can->getTimestamp().toString("h:m"));
+    ui->label_Vdatetime->setText(can->getTimestamp().toString("hh:mm"));
     ui->label_Vtemperature->setText(QString().asprintf("%3.1f degC",can->getExtTemperature()));
     ui->label_Vspeed->setText(QString().asprintf("%2.0f",can->getSpeedImper()));
     ui->label_VbatteryProc->setText(QString().asprintf("%2.0f",can->getBatteryLevelRounded()));


### PR DESCRIPTION
"h:m" changed to "hh:mm".
Example: "06:01" instead of "6:1"

Signed-off-by: Abylay Ospan <aospan@jokersys.com>